### PR TITLE
Packed array version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
 PROTOBUF_CXXFLAGS=$(shell pkg-config protobuf --cflags)
 PROTOBUF_LDFLAGS=$(shell pkg-config protobuf --libs-only-L) -lprotobuf-lite
 
-all: geojson_pb2.py
+all: geojson_pb2.py geojson2_pb2.py
 
 geojson_pb2.py: geojson.proto
 	protoc -I./ --python_out=. ./geojson.proto
+
+geojson2_pb2.py: geojson2.proto
+	protoc -I./ --python_out=. ./geojson2.proto
 
 #decode: decode.cpp
 #	clang++ -o decode decode.cpp $(PROTOBUF_CXXFLAGS) $(PROTOBUF_LDFLAGS)
 
 clean:
 	@rm -f ./geojson_pb2.py
+	@rm -f ./geojson2_pb2.py
 	@rm -f ./decode
 
 test:

--- a/chart.sh
+++ b/chart.sh
@@ -1,0 +1,4 @@
+echo file,geojson,pbf,pbfpacked;
+for file in test/data/*.json;
+    do echo $file,`./encode.py $file`,`./encode2.py $file`;
+done

--- a/decode.py
+++ b/decode.py
@@ -71,4 +71,4 @@ if __name__ == "__main__":
     message = geojson_pb2.object()
     message.ParseFromString(data)
     print message
-    #decode(message) 
+    decode(message)

--- a/encode2.py
+++ b/encode2.py
@@ -15,7 +15,7 @@ geometry_types = ('Point',
                   'GeometryCollection',
                  )
 
-def e6(x): return int(x * 1000)
+def e6(x): return int(x * 1e6)
 
 def encode_geometry(geometry, geom):
     gt = geometry['type']

--- a/geojson2.proto
+++ b/geojson2.proto
@@ -1,0 +1,51 @@
+option optimize_for = LITE_RUNTIME;
+
+message object {
+
+    message value {
+        optional string string_value = 1;
+        optional float float_value = 2;
+        optional double double_value = 3;
+        optional int64 int_value = 4;
+        optional uint64 uint_value = 5;
+        optional sint64 sint_value = 6;
+        optional bool bool_value = 7;
+    }
+
+    message coord_array {
+        repeated int64 coords = 1 [packed=true];
+    }
+
+    message multi_array {
+        repeated coord_array arrays = 1;
+    }
+
+    message geometry {
+        required Type type = 1;
+        repeated coord_array coord_array = 3;
+        repeated multi_array multi_array = 4;
+    }
+
+    enum Type {
+        POINT           = 0;
+        MULTIPOINT      = 1;
+        LINESTRING      = 2;
+        MULTILINESTRING = 3;
+        POLYGON         = 4;
+        MULTIPOLYGON    = 5;
+    }
+
+    message property {
+        required string key = 1;
+        optional value value = 2;
+    }
+
+    message feature {
+        repeated geometry geometries = 2;
+        repeated property properties = 3;
+    }
+
+    required string type = 1;
+    repeated feature features = 2;
+    repeated geometry geometries = 3;
+}


### PR DESCRIPTION
This implements a slimmer geojson encoding in protobuf:
- feature.type is assumed by context, not saved as a string
- geometry.type is an enum
- coordinates are flat and packed
- coordinates are e6 encoded, rather than doubles

Comparison of geojson, geojsonp, and geojsonp-packed: http://bl.ocks.org/anonymous/3026dab639b365bfdfe4

---

Room for improvement:
- Would packed coordinate arrays be more compact if they were stored in dimension order rather than as pairs? like `[x1, x2, x3, y1, y2, y3]`. If they're delta-encoded, the deltas between the same dimension are likely to be smaller than across.
- I had a though that using snappy compression could be a cheap win. It is not: http://bl.ocks.org/anonymous/d750426d2494e25a0606
- I don't see much win coming from msgpack/capnp other serializations - they aim for flexibility or speed of decoding rather than compactness.
